### PR TITLE
fix: 'Error: stream.push() after EOF'

### DIFF
--- a/lib/artifact/runtime-artifact.js
+++ b/lib/artifact/runtime-artifact.js
@@ -60,15 +60,6 @@ module.exports = class RuntimeArtifact extends StaticArtifact {
     close() {
         this._readStream.destroy();
 
-        this._statStream.end();
-        this._statStream.destroy();
-
-        this._filterStream.end()
-        this._filterStream.destroy();
-
-        this._transformStream.end();
-        this._transformStream.destroy();
-
         this._closed = true;
     }
 };


### PR DESCRIPTION
cc @j0tunn 

В самописных стримах нужно реализовывать функцию `destroy`, в которой обрабатывать кейсы, при которых может вызваться `push` в стрим после его закрытия.
Смысла делать это нет, так как достаточно закрыть просто `glob-stream` через метод `destroy` (там внутри все правильно обрабатывается и закрывается, автор пакета это предусмотрел) и позволить нативно завершиться другим стримам.